### PR TITLE
Require contiguous qubits on circuits submitted to ionq devices

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.23.0"
+__extension_version__ = "0.24.0"
 __extension_name__ = "pytket-braket"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.24.0 (unreleased)
+-------------------
+
+* Require circuits submitted to IonQ to have contiguous qubit numbering.
+
 0.23.0 (October 2022)
 ---------------------
 

--- a/pytket/extensions/braket/braket_convert.py
+++ b/pytket/extensions/braket/braket_convert.py
@@ -38,6 +38,7 @@ def tk_to_braket(
     tkcirc: Circuit,
     mapped_qubits: bool = False,
     forced_qubits: Optional[List[int]] = None,
+    force_ops_on_target_qubits: bool = False,
 ) -> Tuple[BK_Circuit, List[int], Dict[int, int]]:
     """
     Convert a tket :py:class:`Circuit` to a braket circuit.
@@ -48,6 +49,7 @@ def tk_to_braket(
         qubit identifiers in the braket circuit
     :param forced_qubits: optional list of braket qubit identifiers to include in the
         converted circuit even if they are unused
+    :param force_ops_on_target_qubits: if True, add no-ops to all target qubits
     :returns: circuit converted to braket; list of braket qubit ids corresponding in
         order of corresponding positions in tkcirc.qubits; (partial) map from braket
         qubit ids to corresponding pytket bit indices holding measurement results
@@ -59,7 +61,8 @@ def tk_to_braket(
         target_qubits.append(bkq)
     measures = {}
     # Add no-ops on all qubits to ensure that even unused qubits are included in bkcirc:
-    bkcirc.i(target_qubits)
+    if force_ops_on_target_qubits:
+        bkcirc.i(target_qubits)
     if forced_qubits is not None:
         bkcirc.i(forced_qubits)
     # Add commands

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -170,8 +170,9 @@ def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
     # Circuit with unused qubits
     c = Circuit(11).H(9).CX(9, 10)
     c = b.get_compiled_circuit(c)
-    h = b.process_circuit(c, 1)
-    b.cancel(h)
+    with pytest.raises(Exception) as e:
+        h = b.process_circuit(c, 1)
+        assert "non-contiguous qubits" in str(e.value)
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)


### PR DESCRIPTION
Fixes #39 .
The ionq backend doesn't allow us to insert no-ops anymore so we can't work around this restriction.
It means we can't attempt noise-aware placement, but this wasn't allowed anyway on ionq devices.