### PR TITLE
[test] Add device availability checks when running remote tests

### DIFF
--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -35,6 +35,10 @@ from pytket.utils.operators import QubitPauliOperator
 skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
 REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of AWS storage)"
 
+def skip_if_device_is_not_available(backend: BraketBackend) -> None:
+    """ Skip the test if the device of the provided `backend` is not available """
+    if not backend._device.is_available:
+        pytest.skip(f"{backend._device.arn} is not available")
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
@@ -44,6 +48,7 @@ REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires configuration of AWS storage
 )
 def test_simulator(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.supports_shots
     c = Circuit(2).H(0).CX(0, 1)
     c.measure_all()
@@ -72,7 +77,6 @@ def test_simulator(authenticated_braket_backend: BraketBackend) -> None:
     assert readout[1] == readout[2]
 
 
-@pytest.mark.skip(reason="https://github.com/CQCL/pytket-braket/issues/7")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 @pytest.mark.parametrize(
     "authenticated_braket_backend",
@@ -81,6 +85,7 @@ def test_simulator(authenticated_braket_backend: BraketBackend) -> None:
 )
 def test_dm_simulator(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.supports_density_matrix
     c = Circuit(2).H(0).SWAP(0, 1)
     cc = b.get_compiled_circuit(c)
@@ -88,7 +93,7 @@ def test_dm_simulator(authenticated_braket_backend: BraketBackend) -> None:
     r = b.get_result(h)
     m = r.get_density_matrix()
     m0 = np.zeros((4, 4), dtype=complex)
-    m0[0, 0] = m0[1, 0] = m0[0, 1] = m0[1, 1] = 0.5
+    m0[0, 0] = m0[2, 0] = m0[0, 2] = m0[2, 2] = 0.5
     assert np.allclose(m, m0)
 
 
@@ -100,6 +105,7 @@ def test_dm_simulator(authenticated_braket_backend: BraketBackend) -> None:
 )
 def test_tn1_simulator(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.supports_shots
     c = Circuit(2).H(0).CX(0, 1)
     c.measure_all()
@@ -131,6 +137,7 @@ def test_tn1_simulator(authenticated_braket_backend: BraketBackend) -> None:
 )
 def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.persistent_handles
     assert b.supports_shots
     assert not b.supports_state
@@ -190,6 +197,7 @@ def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
 )
 def test_rigetti(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.persistent_handles
     assert b.supports_shots
     assert not b.supports_state
@@ -235,6 +243,7 @@ def test_rigetti(authenticated_braket_backend: BraketBackend) -> None:
 def test_rigetti_with_rerouting(authenticated_braket_backend: BraketBackend) -> None:
     # A circuit that requires rerouting to a non-fully-connected architecture
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     c = Circuit(4).CX(0, 1).CX(0, 2).CX(0, 3).CX(1, 2).CX(1, 3).CX(2, 3)
     c = b.get_compiled_circuit(c)
     h = b.process_circuit(c, 10)
@@ -256,6 +265,7 @@ def test_rigetti_with_rerouting(authenticated_braket_backend: BraketBackend) -> 
 )
 def test_oqc(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.persistent_handles
     assert b.supports_shots
     assert not b.supports_state
@@ -482,6 +492,7 @@ def test_shots_bits_edgecases(n_shots: int, n_bits: int) -> None:
 )
 def test_postprocess_ionq(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     assert b.supports_contextual_optimisation
     c = Circuit(2).H(0).CX(0, 1).Y(0)
     c.measure_all()
@@ -560,6 +571,7 @@ def test_multiple_indices() -> None:
 )
 def test_multiple_indices_rigetti(authenticated_braket_backend: BraketBackend) -> None:
     b = authenticated_braket_backend
+    skip_if_device_is_not_available(b)
     c = Circuit(0, 2)
     q0 = Qubit("Z", [0, 0])
     q1 = Qubit("Z", [0, 1])


### PR DESCRIPTION
Fixes #15.

Note that the availability checks are done using the `is_available` property of the `_device` of a `BraketBackend`. Hence, the tests can only be skipped after the properly authenticated backend is created.