### PR TITLE
Update python support to 3.10, 3.11 and 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,47 +38,47 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: Build and test including remote checks (3.10) mypy
+    - name: Build and test (3.10)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy numpy
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Build and test including remote checks (3.11) mypy
       if:  (matrix.os == 'macos-12') && ((github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel') || github.event_name == 'schedule')
       run: |
         ./.github/workflows/build-test mypy numpy
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Build and test including remote checks (3.10) nomypy
+    - name: Build and test including remote checks (3.11) nomypy
       if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy numpy
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
-    - name: Build and test (3.11) - macos and ubuntu
+        python-version: '3.12'
+    - name: Build and test (3.12) - macos and ubuntu
       if: (matrix.os != 'windows-2022') && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy numpy
-    - name: Build and test (3.11) - windows
+    - name: Build and test (3.12) - windows
       if: (matrix.os == 'windows-2022') && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy numpyfix
-    - name: Set up Python 3.12
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - name: Build and test (3.12)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy numpy
     - uses: actions/upload-artifact@v4
       if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,11 +74,6 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy numpy
-    - name: Build and test (3.12) - windows
-      if: (matrix.os == 'windows-2022') && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule')
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy numpyfix
     - uses: actions/upload-artifact@v4
       if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,16 +37,6 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.9
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-    - name: Build and test (3.9)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy numpy
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -79,6 +69,16 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy numpyfix
+    - name: Set up Python 3.12
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build and test (3.12)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy numpy
     - uses: actions/upload-artifact@v4
       if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Some useful links:
 
 ## Getting started
 
-`pytket-braket` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
+`pytket-braket` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Some useful links:
 
 ## Getting started
 
-`pytket-braket` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
-and Windows. To install, run:
+`pytket-braket` is available for Python 3.10 and 3.11, on Linux, MacOS
+and Windows, and Python 3.12 on Linux and MacOS. To install, run:
 
 ```shell
 pip install pytket-braket

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+General:
+
+* Python 3.12 support added, 3.9 dropped.
+* pytket dependency updated to 1.24
+
+
 0.33.0 (January 2024)
 ---------------------
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -4,7 +4,7 @@ pytket-braket
 ``pytket-braket`` is an extension to ``pytket`` that allows ``pytket`` circuits to
 be executed on gate-model quantum devices and simulators via Amazon's Braket service.
 
-``pytket-braket`` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
+``pytket-braket`` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ::

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 warn_unused_configs = True
 
 disallow_untyped_decorators = False

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-braket/index.html",
         "Source": "https://github.com/CQCL/pytket-braket",
@@ -43,7 +43,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.23",
+        "pytket ~= 1.24.0rc0",
         "amazon-braket-sdk ~= 1.53",
         "amazon-braket-schemas ~= 1.19",
         "amazon-braket-default-simulator ~= 1.20",
@@ -51,9 +51,9 @@ setup(
     ],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.24.0rc0",
+        "pytket ~= 1.24",
         "amazon-braket-sdk ~= 1.53",
         "amazon-braket-schemas ~= 1.19",
         "amazon-braket-default-simulator ~= 1.20",


### PR DESCRIPTION
This PR drops python 3.9 support and adds python 3.12.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
