### PR TITLE
feat: Use FullyConnected architecture

### DIFF
--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -82,7 +82,7 @@ from pytket.predicates import (
     NoSymbolsPredicate,
     Predicate,
 )
-from pytket.architecture import Architecture
+from pytket.architecture import Architecture, FullyConnected
 from pytket.placement import NoiseAwarePlacement
 from pytket.utils import prepare_circuit
 from pytket.utils.operators import QubitPauliOperator
@@ -485,7 +485,7 @@ class BraketBackend(Backend):
     @staticmethod
     def _get_arch_info(
         device_properties: Dict[str, Any], device_type: _DeviceType
-    ) -> Tuple[Architecture, List[int]]:
+    ) -> Tuple[Architecture | FullyConnected, List[int]]:
         # return the architecture, and all_qubits
         paradigm = device_properties["paradigm"]
         n_qubits = paradigm["qubitCount"]
@@ -494,6 +494,8 @@ class BraketBackend(Backend):
             connectivity = paradigm["connectivity"]
             if connectivity["fullyConnected"]:
                 all_qubits: List = list(range(n_qubits))
+                arch = FullyConnected(len(all_qubits))
+                return arch, all_qubits
             else:
                 connectivity_graph = connectivity["connectivityGraph"]
                 # Convert strings to ints


### PR DESCRIPTION
# Description

Braket has a field to indicate that a device is fully connected that maps well onto the pytket FullyConnected architecture. This commit changes the utility function that converts between the two models to make use of this. This will change the BackendInfo returned by simulators or devices with full connectivity.

# Related issues

N/A

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
