### PR TITLE
Simplify CI workflows.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,13 +6,7 @@ on:
       - main
   push:
     branches:
-      - main
-      - 'wheel/**'
       - 'runci/**'
-  release:
-    types:
-      - created
-      - edited
   schedule:
     # 04:00 every Tuesday morning
     - cron: '0 4 * * 2'
@@ -26,10 +20,11 @@ env:
 
 jobs:
   braket-checks:
-    name: Braket - Build and test module
+    name: Build and test module
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        pyver: ['3.10', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -37,84 +32,23 @@ jobs:
         fetch-depth: '0'
         submodules: true
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.10
-      if: github.event_name == 'push' || github.event_name == 'schedule'
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-    - name: Build and test (3.10)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
+        python-version: ${{ matrix.pyver }}
+    - name: Build and test (with remote checks, mypy, docs)
+      if: (matrix.os == 'ubuntu-latest') && (matrix.pyver == '3.10')
       shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Build and test including remote checks (3.11) mypy
-      if:  (matrix.os == 'macos-latest') && ((github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel') || github.event_name == 'schedule')
       run: |
         ./.github/workflows/build-test mypy
-      env:
-        PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Build and test including remote checks (3.11) nomypy
-      if:  (matrix.os != 'macos-latest') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
-      env:
-        PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Set up Python 3.12
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - name: Build and test (3.12)
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
-    - uses: actions/upload-artifact@v4
-      if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
-      with:
-        name: artefact-${{ matrix.os }}
-        path: wheelhouse/
-    - name: install poetry
-      run: pip install poetry
-    - name: Install docs dependencies
-      if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request')
-      run: |
+        pip install poetry
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
-    - name: Build docs
-      if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request')
-      timeout-minutes: 20
-      run: |
-        cd docs
         poetry run bash ./build-docs.sh
-
-  publish_to_pypi:
-    name: Publish to pypi
-    if: github.event_name == 'release'
-    needs: braket-checks
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download all wheels
-      # downloading all three files into the wheelhouse
-      # all files are identical, so there will only be one file
-      uses: actions/download-artifact@v4
-      with:
-        path: wheelhouse
-        pattern: artefact-*
-        merge-multiple: true
-    - name: Put them all in the dist folder
+      env:
+        PYTKET_RUN_REMOTE_TESTS: 1
+    - name: Build and test (with no remote checks, no mypy)
+      if: (matrix.os != 'ubuntu-latest') || (matrix.pyver != '3.10')
+      shell: bash
       run: |
-        mkdir dist
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do cp $w dist/ ; done
-    - name: Publish wheels
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PYTKET_BRAKET_API_TOKEN }}
-        verbose: true
+        ./.github/workflows/build-test nomypy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'wheel/**'
+  release:
+    types:
+      - created
+      - edited
+
+jobs:
+  braket-checks:
+    name: Build, test and store artifact
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+        submodules: true
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Build and test
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wheel
+        path: wheelhouse/
+
+  publish_to_pypi:
+    name: Publish to pypi
+    if: github.event_name == 'release'
+    needs: braket-checks
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Download wheel
+      uses: actions/download-artifact@v4
+      with:
+        path: wheelhouse
+        pattern: wheel
+    - name: Put it in the dist folder
+      run: |
+        mkdir dist
+        for w in `find wheelhouse/ -type f -name "*.whl"` ; do cp $w dist/ ; done
+    - name: Publish wheel
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PYTKET_BRAKET_API_TOKEN }}
+        verbose: true


### PR DESCRIPTION
Closes #174 .

Splits the workflow into two:
* PRs to `main`, pushes to `runci/**` and scheduled runs trigger `build_and_test.yml` which runs basic tests on all platforms and Python 3.10 and 3.12; and runs extended (remote) tests, mypy and docs build on Linux with Python 3.10.
* Releases and pushes to `wheel/**` trigger `release.yml` which runs basic tests on Linux with Python 3.10, generates a wheel as an artifact and (for releases) uploads it to pypi.

I think this makes the workflows a lot simpler and easier to understand.

I will fix up the list of names of required checks after merging.

The release workflow has been tested [here](https://github.com/CQCL/pytket-braket/actions/runs/13766454301).