### PR TITLE
fix: make the default compilation pass serializable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Unreleased
 ----------
 
 * Python 3.13 support added.
-* Replaced internal usage of :py:class:`~pytket.passes.RebaseCustom` and :py:class:`~pytket.passes.SquashCustom` so that the :py:meth:`BraketBackend.default_compilation_pass` is serializable.
+* Replaced internal usage of :py:class:`~pytket.passes.RebaseCustom` and :py:class:`~pytket.passes.SquashCustom` so that the :py:meth:`BraketBackend.default_compilation_pass` method is serializable.
 
 0.40.0 (March 2025)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,11 +7,12 @@ Unreleased
 ----------
 
 * Python 3.13 support added.
+* Replaced internal usage of :py:class:`~pytket.passes.RebaseCustom` and :py:class:`~pytket.passes.SquashCustom` so that the :py:meth:`BraketBackend.default_compilation_pass` is serializable.
 
 0.40.0 (March 2025)
 -------------------
 
-* Update pytket minimium version requirement to 2.0.1.
+* Update pytket minimum version requirement to 2.0.1.
 * Update to new schema for Rigetti devices.
 
 0.39.0 (January 2025)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Unreleased
 ----------
 
 * Python 3.13 support added.
-* Replaced internal usage of :py:class:`~pytket.passes.RebaseCustom` and :py:class:`~pytket.passes.SquashCustom` so that the :py:meth:`BraketBackend.default_compilation_pass` method is serializable.
+* Replaced internal usage of :py:class:`~pytket.passes.RebaseCustom` and :py:class:`~pytket.passes.SquashCustom` so that the :py:meth:`BraketBackend.default_compilation_pass` method uses only serializable passes.
 
 0.40.0 (March 2025)
 -------------------

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -65,7 +65,6 @@ from pytket.passes import (
     SynthesiseTket,
     FullPeepholeOptimise,
     CliffordSimp,
-    SquashCustom,
     DecomposeBoxes,
     SimplifyInitial,
     NaivePlacementPass,

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -456,7 +456,7 @@ class BraketBackend(Backend):
         multiqs = set()
         singleqs = set()
         if not {"cnot", "rx", "rz", "x"} <= supported_ops:
-            # This is so that we can define RebaseCustom without prior knowledge of the
+            # This is so that we can define AutoRebase without prior knowledge of the
             # gate set, and use X as the bit-flip gate in contextual optimization. We
             # could do better than this, by defining different options depending on the
             # supported gates. But it seems all existing backends support these gates.

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -71,7 +71,6 @@ from pytket.passes import (
     AutoRebase,
     AutoSquash,
 )
-from pytket.circuit_library import TK1_to_RzRx
 from pytket.pauli import Pauli, QubitPauliString
 from pytket.predicates import (
     ConnectivityPredicate,

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -60,7 +60,6 @@ from pytket.circuit import Circuit, OpType
 from pytket.passes import (
     BasePass,
     CXMappingPass,
-    RebaseCustom,
     RemoveRedundancies,
     SequencePass,
     SynthesiseTket,
@@ -70,6 +69,8 @@ from pytket.passes import (
     DecomposeBoxes,
     SimplifyInitial,
     NaivePlacementPass,
+    AutoRebase,
+    AutoSquash,
 )
 from pytket.circuit_library import TK1_to_RzRx
 from pytket.pauli import Pauli, QubitPauliString
@@ -447,15 +448,8 @@ class BraketBackend(Backend):
         ):
             self._req_preds.append(ConnectivityPredicate(arch))
 
-        self._rebase_pass = RebaseCustom(
-            self._multiqs | self._singleqs,
-            Circuit(),
-            TK1_to_RzRx,
-        )
-        self._squash_pass = SquashCustom(
-            self._singleqs,
-            TK1_to_RzRx,
-        )
+        self._rebase_pass = AutoRebase(self._multiqs | self._singleqs)
+        self._squash_pass = AutoSquash(self._singleqs)
 
     @staticmethod
     def _get_gate_set(

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -23,6 +23,7 @@ from pytket.extensions.braket import BraketBackend
 from pytket.architecture import FullyConnected
 from pytket.circuit import Circuit, OpType, Qubit, Bit
 from pytket.pauli import Pauli, QubitPauliString
+from pytket.passes import SequencePass, BasePass
 from pytket.utils.expectations import (
     get_pauli_expectation_value,
     get_operator_expectation_value,
@@ -633,3 +634,14 @@ def test_multiple_indices_rigetti(authenticated_braket_backend: BraketBackend) -
     c1 = b.get_compiled_circuit(c)
     h = b.process_circuit(c1, 100)
     b.cancel(h)
+
+
+def test_default_pass_serialization(
+    authenticated_braket_backend: BraketBackend,
+) -> None:
+    for opt_level in range(3):
+        default_pass = authenticated_braket_backend.default_compilation_pass(opt_level)
+        original_pass_dict = default_pass.to_dict()
+        reconstructed_pass = BasePass.from_dict(original_pass_dict)
+        assert isinstance(reconstructed_pass, SequencePass)
+        assert original_pass_dict == reconstructed_pass.to_dict()


### PR DESCRIPTION
# Description

Removing the usage of `SquashCustom` and `RebaseCustom` so that the `default_compilation_pass` is serializable.

I think we should make a release after this.

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
