### PR TITLE
Change default optimization level to 2.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 * Python 3.13 support added.
+* Changed default optimization level from 1 to 2.
 
 0.40.0 (March 2025)
 -------------------

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -665,7 +665,7 @@ class BraketBackend(Backend):
     def rebase_pass(self) -> BasePass:
         return self._rebase_pass
 
-    def default_compilation_pass(self, optimisation_level: int = 1) -> BasePass:
+    def default_compilation_pass(self, optimisation_level: int = 2) -> BasePass:
         assert optimisation_level in range(3)
         passes = [DecomposeBoxes()]
         if optimisation_level == 1:


### PR DESCRIPTION
As noted [here](https://github.com/CQCL/pytket-braket/pull/179#issuecomment-2873273223).