### PR TITLE
Add "barrier" to set of recognized gate types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Add "barrier" to set of recognized gate types.
+
 0.46.0 (January 2026)
 ---------------------
 

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -106,6 +106,7 @@ IQM_SCHEMA = {
 
 _gate_types = {
     "amplitude_damping": None,
+    "barrier": OpType.Barrier,
     "bit_flip": None,
     "ccnot": OpType.CCX,
     "cc_prx": None,


### PR DESCRIPTION
Tests were failing with a `KeyError` due to the presence of this newly (?) supported op.