### PR TITLE
Fix test failures

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyver: ["3.12"]
+        pyver: ["3.13"]
     uses: Quantinuum/pytket-workflows/.github/workflows/static-checks-wf.yml@v1
     with:
       os: ${{ matrix.os }}
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        pyver: ["3.10", "3.13"]
+        pyver: ["3.11", "3.13"]
     uses: Quantinuum/pytket-workflows/.github/workflows/unit-test-wf.yml@v1
     with:
       os: ${{ matrix.os }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        pyver: ["3.11"]
+        pyver: ["3.12"]
     uses: Quantinuum/pytket-workflows/.github/workflows/unit-test-remote-wf.yml@v1
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build, test, and store artifact, and upload to pypi
     uses: Quantinuum/pytket-workflows/.github/workflows/release-wf.yml@v1
     with:
-      pyver: "3.10"
+      pyver: "3.11"
       publish: ${{ github.event_name == 'release' }}
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_PYTKET_BRAKET_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Some useful links:
 
 ## Getting started
 
-`pytket-braket` is compatible with Python versions 3.10 to 3.13 on Linux, MacOS
+`pytket-braket` is compatible with Python versions 3.11 to 3.13 on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,8 +3,8 @@
 Changelog
 ~~~~~~~~~
 
-Unreleased
-~~~~~~~~~~
+0.48.0 (June 2026)
+~~~~~~~~~~~~~~~~~~
 
 * Drop support for Python 3.10.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+~~~~~~~~~~
+
+* Drop support for Python 3.10.
+
 0.47.0 (May 2026)
 -----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ pytket-braket
 ``pytket-braket`` is an extension to ``pytket`` that allows ``pytket`` circuits to
 be executed on gate-model quantum devices and simulators via Amazon's Braket service.
 
-``pytket-braket`` is compatible with Python versions 3.10 to 3.13 on Linux,
+``pytket-braket`` is compatible with Python versions 3.11 to 3.13 on Linux,
 MacOS and Windows. To install, run:
 
 ::

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.11
 warn_unused_configs = True
 
 disallow_untyped_decorators = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 ]
 dependencies = [
     "pytket >= 2.18.0",
-    "amazon-braket-sdk ~= 1.101",
-    "amazon-braket-schemas ~= 1.26",
-    "amazon-braket-default-simulator ~= 1.29",
+    "amazon-braket-sdk ~= 1.120",
+    "amazon-braket-schemas ~= 1.31",
+    "amazon-braket-default-simulator ~= 1.39",
     "boto3-stubs",
     "llvmlite>=0.37.0",
     "numba>=0.48.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytket-braket"
 dynamic = ["version"]
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.11,<4.0"
 
 description = "Extension for pytket, providing access to Amazon Braket backends"
 license = { file = "LICENSE" }
@@ -14,7 +14,6 @@ maintainers = [
 ]
 classifiers = [
     "Environment :: Console",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pytket/extensions/braket/_metadata.py
+++ b/pytket/extensions/braket/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.47.0"
+__extension_version__ = "0.48.0"
 __extension_name__ = "pytket-braket"

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -1002,7 +1002,7 @@ class BraketBackend(Backend):
 
             props = aws_device.properties.dict()
             try:
-                device_info = props["action"][DeviceActionType.JAQCD]
+                device_info = props["action"][DeviceActionType.OPENQASM]
                 supported_ops = {
                     op.lower() for op in device_info["supportedOperations"]
                 }

--- a/pytket/extensions/braket/backends/braket.py
+++ b/pytket/extensions/braket/backends/braket.py
@@ -688,7 +688,7 @@ class BraketBackend(Backend):
             return SequencePass(passes)
         return self._rebase_pass
 
-    def default_compilation_pass(self, optimisation_level: int = 2) -> BasePass:
+    def default_compilation_pass(self, optimisation_level: int = 2) -> BasePass:  # noqa: PLR0912
         assert optimisation_level in range(3)
         if not self.verbatim:
             passes = [DecomposeBoxes()]
@@ -703,19 +703,19 @@ class BraketBackend(Backend):
                 and (not self._requires_all_qubits_measured)
             ):
                 arch = self.backend_info.architecture
-                assert isinstance(arch, Architecture)
-                passes.append(
-                    CXMappingPass(
-                        arch,
-                        NoiseAwarePlacement(
+                if isinstance(arch, Architecture):
+                    passes.append(
+                        CXMappingPass(
                             arch,
-                            **get_avg_characterisation(self.characterisation),  # type: ignore
-                        ),
-                        directed_cx=False,
-                        delay_measures=True,
+                            NoiseAwarePlacement(
+                                arch,
+                                **get_avg_characterisation(self.characterisation),  # type: ignore
+                            ),
+                            directed_cx=False,
+                            delay_measures=True,
+                        )
                     )
-                )
-                passes.append(NaivePlacementPass(arch))
+                    passes.append(NaivePlacementPass(arch))
                 passes.append(self.rebase_pass())
                 # If CX weren't supported by the device then we'd need to do another
                 # rebase_pass here. But we checked above that it is.

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -208,7 +208,7 @@ def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
     assert b.valid_circuit(c1)
     c2 = b.get_compiled_circuit(c, optimisation_level=2)
     assert b.valid_circuit(c2)
-    h = b.process_circuit(c0, 10)
+    h = b.process_circuit(c0, 100)
     _ = b.circuit_status(h)
     b.cancel(h)
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -208,17 +208,15 @@ def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
     assert b.valid_circuit(c1)
     c2 = b.get_compiled_circuit(c, optimisation_level=2)
     assert b.valid_circuit(c2)
-    # Commented out because of
-    # https://github.com/Quantinuum/pytket-braket/issues/223
-    # h = b.process_circuit(c0, 100)
-    # _ = b.circuit_status(h)
-    # b.cancel(h)
+    h = b.process_circuit(c0, 100)
+    _ = b.circuit_status(h)
+    b.cancel(h)
 
     # Circuit with unused qubits
     c = Circuit(11).H(9).CX(9, 10)
     c = b.get_compiled_circuit(c)
     with pytest.raises(Exception) as e:
-        _ = b.process_circuit(c, 1)
+        h = b.process_circuit(c, 1)
         assert "non-contiguous qubits" in str(e.value)
 
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -208,15 +208,17 @@ def test_ionq(authenticated_braket_backend: BraketBackend) -> None:
     assert b.valid_circuit(c1)
     c2 = b.get_compiled_circuit(c, optimisation_level=2)
     assert b.valid_circuit(c2)
-    h = b.process_circuit(c0, 100)
-    _ = b.circuit_status(h)
-    b.cancel(h)
+    # Commented out because of
+    # https://github.com/Quantinuum/pytket-braket/issues/223
+    # h = b.process_circuit(c0, 100)
+    # _ = b.circuit_status(h)
+    # b.cancel(h)
 
     # Circuit with unused qubits
     c = Circuit(11).H(9).CX(9, 10)
     c = b.get_compiled_circuit(c)
     with pytest.raises(Exception) as e:
-        h = b.process_circuit(c, 1)
+        _ = b.process_circuit(c, 1)
         assert "non-contiguous qubits" in str(e.value)
 
 


### PR DESCRIPTION
See individual commits.

Dropping support for Python 3.10 is necessary to support latest `amazon-braket-default-simulator`.

We should probably do a new release.

We also need to modify the names of the required checks. I'll do that after merge.